### PR TITLE
chore: pin shared workflows to v0.3.3

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     steps:
       - name: Auto-merge Dependabot PR
-        uses: django-mvp/shared/.github/actions/auto-merge-dependabot@v0.3.2
+        uses: django-mvp/shared/.github/actions/auto-merge-dependabot@v0.3.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pr-url: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   call-build:
-    uses: django-mvp/shared/.github/workflows/build.yml@v0.3.2
+    uses: django-mvp/shared/.github/workflows/build.yml@v0.3.3
     with:
       source-dir: project
       python-version: '3.13'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   call-docs:
-    uses: django-mvp/shared/.github/workflows/docs.yml@v0.3.2
+    uses: django-mvp/shared/.github/workflows/docs.yml@v0.3.3
     secrets: inherit

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -86,7 +86,7 @@ jobs:
   call-prepare-release:
     name: Open release PR
     needs: compute-version
-    uses: django-mvp/shared/.github/workflows/prepare-release.yml@v0.3.2
+    uses: django-mvp/shared/.github/workflows/prepare-release.yml@v0.3.3
     with:
       # The shared workflow passes this straight to `poetry version`, which
       # accepts an explicit version as readily as a bump level.

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -20,6 +20,6 @@ permissions:
 
 jobs:
   call-tag-release:
-    uses: django-mvp/shared/.github/workflows/tag-release.yml@v0.3.2
+    uses: django-mvp/shared/.github/workflows/tag-release.yml@v0.3.3
     secrets:
       RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   call-tests:
-    uses: django-mvp/shared/.github/workflows/tests.yml@v0.3.2
+    uses: django-mvp/shared/.github/workflows/tests.yml@v0.3.3
     with:
       coverage-package: project
       # This is a deployed application, not a library, so it runs on exactly one


### PR DESCRIPTION
Bumps all `django-mvp/shared/.github/...` references from v0.3.2 to v0.3.3.

Depends on [django-mvp/shared#36](https://github.com/django-mvp/shared/pull/36) merging and the v0.3.3 tag being cut — CI on this PR will not resolve the shared action/workflow refs until then. Hold merge until v0.3.3 exists.